### PR TITLE
Explicitly set JAVA_HOME

### DIFF
--- a/common-services/SOLR/serviceVersion/package/scripts/service_check.py
+++ b/common-services/SOLR/serviceVersion/package/scripts/service_check.py
@@ -30,6 +30,7 @@ class ServiceCheck(Script):
             Execute(
                 format('{solr_config_bin_dir}/solr create_core -c {solr_collection_name}' +
                        ' -d {solr_collection_config_dir} -p {solr_config_port} >> {solr_config_service_log_file} 2>&1'),
+                environment={'JAVA_HOME': params.java64_home},
                 user=params.solr_config_user
             )
         else:
@@ -38,6 +39,7 @@ class ServiceCheck(Script):
                        ' -d {solr_collection_config_dir} -p {solr_config_port}' +
                        ' -s {solr_collection_shards} -rf {solr_collection_replicas}' +
                        ' >> {solr_config_service_log_file} 2>&1'),
+                environment={'JAVA_HOME': params.java64_home},
                 user=params.solr_config_user
             )
 

--- a/common-services/SOLR/serviceVersion/package/scripts/solr.py
+++ b/common-services/SOLR/serviceVersion/package/scripts/solr.py
@@ -72,6 +72,7 @@ class Solr(Script):
 
         Execute(
             start_command,
+            environment={'JAVA_HOME': params.java64_home},            
             user=params.solr_config_user
         )
 
@@ -81,6 +82,7 @@ class Solr(Script):
 
         Execute(
             format('{solr_config_bin_dir}/solr stop -all >> {solr_config_service_log_file} 2>&1'),
+            environment={'JAVA_HOME': params.java64_home},
             user=params.solr_config_user
         )
 


### PR DESCRIPTION
When testing locally, I noticed my start/stop/service check commands were failing with the following exception:
    
    A working Java 7 or later is required to run Solr!
    Please install Java or fix JAVA_HOME before running this script.
    Command that we tried: 'java -version'
    Active Path:
    /usr/sbin:/sbin:/usr/lib/ambari-server/*:/usr/sbin:/sbin:/usr/lib/ambari-server/*:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/var/lib/ambari-agent:/var/lib/ambari-agent

This is with a typical default install, where my root user does not have a JAVA_HOME/PATH set.  By adding the explicit environment we can make sure these commands will run properly when the user running the Ambari Agent does not have their JAVA_HOME/PATH set properly.