### PR TITLE
LWSHADOOP-693 Add solr 6.4.2 to HDP stack

### DIFF
--- a/src/main/mpack/custom-services/SOLR/6.4.2/metainfo.xml
+++ b/src/main/mpack/custom-services/SOLR/6.4.2/metainfo.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>SOLR</name>
+            <extends>common-services/SOLR/5.5.2</extends>
+            <version>6.4.2</version>
+        </service>
+    </services>
+</metainfo>

--- a/src/main/mpack/mpack.json
+++ b/src/main/mpack/mpack.json
@@ -11,8 +11,7 @@
     {
       "name": "solr-service-definitions ",
       "type": "service-definitions",
-      "source_dir": "common-services",
-      "service_version": "5.5.2"
+      "source_dir": "common-services"
     },
     {
       "name" : "solr-extension-definitions",
@@ -30,7 +29,17 @@
           "applicable_stacks" : [
             {
               "stack_name" : "HDP",
-              "stack_version" : "2.4"
+              "stack_version" : "2.5"
+            }
+          ]
+        },
+       {
+          "service_name" : "SOLR",
+          "service_version" : "6.4.2",
+          "applicable_stacks" : [
+            {
+              "stack_name" : "HDP",
+              "stack_version" : "2.6"
             }
           ]
         }


### PR DESCRIPTION
Solr 6.4.2 RC1 was added to HDP 2.6 stack for now. Packages can be found here: https://ci.lucidworks.com/job/Partners/job/hadoop-pkg-hdpsearch/224/

TODO:

- Before merge this PR, change the stack version appropriately.