### PR TITLE
role command order - stop dependent components

### DIFF
--- a/src/main/mpack/common-services/SOLR/5.5.5/role_command_order.json
+++ b/src/main/mpack/common-services/SOLR/5.5.5/role_command_order.json
@@ -12,10 +12,14 @@
     "SOLR_SERVICE_CHECK-SERVICE_CHECK": [
       "SOLR_SERVER-START"
     ],
-    "SOLR_SERVER-STOP": [
-      "DATANODE-STOP",
-      "NAMENODE-STOP",
-      "SECONDARY_NAMENODE-STOP"
+    "DATANODE-STOP": [
+      "SOLR_SERVER-STOP"
+    ],
+    "NAMENODE-STOP": [
+      "SOLR_SERVER-STOP"
+    ],
+    "ZOOKEEPER_SERVER-STOP": [
+      "SOLR_SERVER-STOP"
     ]
   }
 }


### PR DESCRIPTION
Repairment of #24.
 
According documentation: https://cwiki.apache.org/confluence/display/AMBARI/How-To+Define+Stacks+and+Services#How-ToDefineStacksandServices-RoleCommandOrder, we must stop dependent solr server components earlier, than datanode, namenode, zookeper.