### PR TITLE
LWSHADOOP-750: Add SUSE 12 as supported OS

### DIFF
--- a/src/main/template/repos/repoinfo.xml
+++ b/src/main/template/repos/repoinfo.xml
@@ -39,12 +39,11 @@
         </repo>
     </os>
     <os family="suse12">
-    <repo>
-        <baseurl>http://public-repo-1.hortonworks.com/{REPOID}/repos/sles12</baseurl>
-        <repoid>{REPOID}</repoid>
-        <reponame>HDP-SOLR</reponame>
-    </repo>
-
+        <repo>
+            <baseurl>http://public-repo-1.hortonworks.com/{REPOID}/repos/sles12</baseurl>
+            <repoid>{REPOID}</repoid>
+            <reponame>HDP-SOLR</reponame>
+        </repo>
 </os>
     <os family="debian6">
         <repo>

--- a/src/main/template/repos/repoinfo.xml
+++ b/src/main/template/repos/repoinfo.xml
@@ -38,6 +38,14 @@
             <reponame>HDP-SOLR</reponame>
         </repo>
     </os>
+    <os family="suse12">
+    <repo>
+        <baseurl>http://public-repo-1.hortonworks.com/{REPOID}/repos/sles12</baseurl>
+        <repoid>{REPOID}</repoid>
+        <reponame>HDP-SOLR</reponame>
+    </repo>
+
+</os>
     <os family="debian6">
         <repo>
             <baseurl>http://public-repo-1.hortonworks.com/{REPOID}/repos/debian6</baseurl>


### PR DESCRIPTION
This adds SLES12 as one of the supported repos for solr-stack installation.