### PR TITLE
LWSHADOOP-748: Look in HDFS Index Dir when deleting write.lock files

### DIFF
--- a/src/main/mpack/common-services/SOLR/5.5.5/package/scripts/solr_utils.py
+++ b/src/main/mpack/common-services/SOLR/5.5.5/package/scripts/solr_utils.py
@@ -6,7 +6,7 @@ from resource_management.core.resources.system import Execute
 from resource_management.core.shell import call
 from resource_management.libraries.functions.format import format
 
-COLLECTION_PATTERN = "\/solr\/[a-zA-Z0-9\._-]+"
+COLLECTION_PATTERN = "{solr_hdfs_directory}/[a-zA-Z0-9\._-]+"
 CORE_PATTERN = "{collection_path}\/core_node[0-9]+"
 WRITE_LOCK_PATTERN = "{0}/data/index/write.lock "
 
@@ -62,7 +62,9 @@ def exists_collection(collection_name):
 
 
 def get_collection_paths(hadoop_output):
-    pattern = re.compile(COLLECTION_PATTERN)
+    import params
+    pattern = re.compile(format(COLLECTION_PATTERN))
+
     collection_paths = re.findall(pattern, hadoop_output)
     return collection_paths
 

--- a/src/main/mpack/common-services/SOLR/6.6.2/package/scripts/solr_utils.py
+++ b/src/main/mpack/common-services/SOLR/6.6.2/package/scripts/solr_utils.py
@@ -6,7 +6,7 @@ from resource_management.core.resources.system import Execute
 from resource_management.core.shell import call
 from resource_management.libraries.functions.format import format
 
-COLLECTION_PATTERN = "\/solr\/[a-zA-Z0-9\._-]+"
+COLLECTION_PATTERN = "{solr_hdfs_directory}/[a-zA-Z0-9\._-]+"
 CORE_PATTERN = "{collection_path}\/core_node[0-9]+"
 WRITE_LOCK_PATTERN = "{0}/data/index/write.lock "
 
@@ -62,7 +62,9 @@ def exists_collection(collection_name):
 
 
 def get_collection_paths(hadoop_output):
-    pattern = re.compile(COLLECTION_PATTERN)
+    import params
+    pattern = re.compile(format(COLLECTION_PATTERN))
+
     collection_paths = re.findall(pattern, hadoop_output)
     return collection_paths
 


### PR DESCRIPTION
Ambari provides an option for users to have their write.lock files deleted
on startup, if they'd like.

Prior to this commit, this cleanup was hardcoded to look in the default
HDFS index dir: `/solr`.  This leaves lock files behind, and causes
problems for the Solr processes during or after startup.

This commit switches the cleanup over to using the user-specified
configuration option, instead of the hardcoded path.