### PR TITLE
hostname regular pattern repairment

### DIFF
--- a/src/main/mpack/common-services/SOLR/5.5.5/package/scripts/solr_utils.py
+++ b/src/main/mpack/common-services/SOLR/5.5.5/package/scripts/solr_utils.py
@@ -9,7 +9,7 @@ from resource_management.libraries.functions.format import format
 COLLECTION_PATTERN = "{solr_hdfs_directory}/[a-zA-Z0-9\._-]+"
 CORE_PATTERN = "{collection_path}\/core_node[0-9]+"
 WRITE_LOCK_PATTERN = "{0}/data/index/write.lock "
-HOSTNAME_VERIFIER_PATTERN = "{core_node_name}\":{{((?![^_]shard|core_node).)*\"node_name\":\"{solr_hostname}"
+HOSTNAME_VERIFIER_PATTERN = "{core_node_name}\":{{((?!\"shard|\"core_node).)*\"node_name\":\"{solr_hostname}"
 
 
 def solr_port_validation():

--- a/src/main/mpack/common-services/SOLR/6.6.2/package/scripts/solr_utils.py
+++ b/src/main/mpack/common-services/SOLR/6.6.2/package/scripts/solr_utils.py
@@ -9,7 +9,7 @@ from resource_management.libraries.functions.format import format
 COLLECTION_PATTERN = "{solr_hdfs_directory}/[a-zA-Z0-9\._-]+"
 CORE_PATTERN = "{collection_path}\/core_node[0-9]+"
 WRITE_LOCK_PATTERN = "{0}/data/index/write.lock "
-HOSTNAME_VERIFIER_PATTERN = "{core_node_name}\":{{((?![^_]shard|core_node).)*\"node_name\":\"{solr_hostname}"
+HOSTNAME_VERIFIER_PATTERN = "{core_node_name}\":{{((?!\"shard|\"core_node).)*\"node_name\":\"{solr_hostname}"
 
 
 def solr_port_validation():


### PR DESCRIPTION
I found that there is in the hostname regular, one small bug.
I added that matched text mustn't contains shard and core_node with double quotes.