### PR TITLE
LWSHADOOP-721: Use ticket cache for Solr<->ZK Conn

### DIFF
--- a/src/main/mpack/common-services/SOLR/5.5.5/package/templates/solr_server_jaas.conf.j2
+++ b/src/main/mpack/common-services/SOLR/5.5.5/package/templates/solr_server_jaas.conf.j2
@@ -3,7 +3,7 @@ Client {
   useKeyTab=true
   keyTab="{{solr_kerberos_keytab}}"
   storeKey=true
-  useTicketCache=false
+  useTicketCache=true
   debug=false
   principal="{{solr_kerberos_principal}}";
 };

--- a/src/main/mpack/common-services/SOLR/6.6.2/package/templates/solr_server_jaas.conf.j2
+++ b/src/main/mpack/common-services/SOLR/6.6.2/package/templates/solr_server_jaas.conf.j2
@@ -3,7 +3,7 @@ Client {
   useKeyTab=true
   keyTab="{{solr_kerberos_keytab}}"
   storeKey=true
-  useTicketCache=false
+  useTicketCache=true
   debug=false
   principal="{{solr_kerberos_principal}}";
 };


### PR DESCRIPTION
Prior to this commit, when Solr was connecting to ZK with Kerberos
enabled, it would use a specified keytab only.  It would not attempt
to connect via a ticket cache.

With this commit, Solr will attempt to use the ticket cache first,
before falling back to explicitly using the keytab.  For more
information, see:
https://docs.oracle.com/javase/8/docs/jre/api/security/jaas/spec/com/sun/security/auth/module/Krb5LoginModule.html