### PR TITLE
LWSHADOOP-658: Request Solr-restart when AMS changes

### DIFF
--- a/src/main/mpack/common-services/SOLR/5.5.5/metainfo.xml
+++ b/src/main/mpack/common-services/SOLR/5.5.5/metainfo.xml
@@ -58,6 +58,7 @@
                 <config-type>example-collection</config-type>
                 <config-type>solr-security</config-type>
                 <config-type>solr-metrics</config-type>
+                <config-type>ams-env</config-type>
             </configuration-dependencies>
             <restartRequiredAfterChange>true</restartRequiredAfterChange>
 


### PR DESCRIPTION
The addition of the Ambari Metric Service (AMS) to a cluster affects
any other services there that publish metrics to AMS.  So when AMS
is installed or is restarted after a configuration change, these
related services also need to be restarted.  Ambari notes this for many
other services by putting a small "Restart Required" icon next to the
service name.

Prior to this commit, Solr didn't declare its relationship to AMS
correctly, and wasn't being properly marked as "Restart Required".  This
commit changes the Solr mpack metadata to note that it needs to be
sensitive to changes in AMS configuration and be restarted when AMS is
installed, restarted after config changes, etc.