### PR TITLE
Prepare SOLR-7.4.0 stack for Ambari 2.7.0

### DIFF
--- a/src/main/mpack/common-services/SOLR/7.4.0/configuration/solr-config-env.xml
+++ b/src/main/mpack/common-services/SOLR/7.4.0/configuration/solr-config-env.xml
@@ -217,4 +217,38 @@
           <property-file-type>xml</property-file-type>
         </value-attributes>
     </property>
+
+    <property>
+        <name>solr_config_user</name>
+        <value>solr</value>
+        <property-type>USER</property-type>
+        <description>User for Solr service</description>
+        <value-attributes>
+            <type>user</type>
+            <overridable>false</overridable>
+            <user-groups>
+                <property>
+                    <type>cluster-env</type>
+                    <name>user_group</name>
+                </property>
+                <property>
+                    <type>solr-env</type>
+                    <name>solr_group</name>
+                </property>
+            </user-groups>
+        </value-attributes>
+        <display-name>Solr user</display-name>
+    </property>
+
+    <property>
+        <name>solr_config_group</name>
+        <value>solr</value>
+        <property-type>GROUP</property-type>
+        <description>Group for Solr service</description>
+        <value-attributes>
+            <type>group</type>
+            <overridable>false</overridable>
+        </value-attributes>
+        <display-name>Solr group</display-name>
+    </property>
 </configuration>

--- a/src/main/mpack/common-services/SOLR/7.4.0/package/scripts/params.py
+++ b/src/main/mpack/common-services/SOLR/7.4.0/package/scripts/params.py
@@ -28,10 +28,10 @@ def build_zookeeper_hosts():
 
 config = Script.get_config()
 
-java64_home = config['hostLevelParams']['java_home']
-hostname = config['hostname']
+java64_home = config['ambariLevelParams']['java_home']
+hostname = config['agentLevelParams']['hostname']
 zk_client_port = str(default('/configurations/zoo.cfg/clientPort', None))
-zookeeper_hosts_list = config['clusterHostInfo']['zookeeper_hosts']
+zookeeper_hosts_list = default("/clusterHostInfo/zookeeper_server_hosts", [])
 zookeeper_hosts = build_zookeeper_hosts()
 
 map_solr_config = config['configurations']['solr-config-env']
@@ -96,7 +96,7 @@ if solr_hdfs_enable:
     hdfs_site = config['configurations']['hdfs-site']
     hdfs_user_keytab = config['configurations']['hadoop-env']['hdfs_user_keytab']
     default_fs = config['configurations']['core-site']['fs.defaultFS']
-    dfs_type = default('/commandParams/dfs_type', '')
+    dfs_type = default('/clusterLevelParams/dfs_type', '')
     hdfs_principal_name = config['configurations']['hadoop-env']['hdfs_principal_name']
     solr_hdfs_delete_write_lock_files = bool(map_solr_hdfs['solr_hdfs_delete_write_lock_files'])
 

--- a/src/main/mpack/mpack.json
+++ b/src/main/mpack/mpack.json
@@ -55,7 +55,7 @@
           "applicable_stacks": [
             {
               "stack_name": "HDP",
-              "stack_version": "2.6"
+              "stack_version": "3.0"
             }
           ]
         }


### PR DESCRIPTION
Ambari 2.7 included a few changes in the configuration structure which
caused issues with our Solr mpack.  This commit tweaks some of our
configuration references to work against the more recent 2.7.0+ config
structure.