### PR TITLE
Update Solr 7.4.0 logging templates to log4j2

### DIFF
--- a/src/main/mpack/common-services/SOLR/7.4.0/configuration/solr-config-env.xml
+++ b/src/main/mpack/common-services/SOLR/7.4.0/configuration/solr-config-env.xml
@@ -139,10 +139,10 @@
             # Solr provides a default Log4J configuration properties file in server/resources
             # however, you may want to customize the log settings and file appender location
             # so you can point the script to use a different log4j.properties file
-            LOG4J_PROPS={{solr_config_conf_dir}}/log4j.properties
+            LOG4J_PROPS={{solr_config_conf_dir}}/log4j2.xml
 
             # Changes the logging level. Valid values: ALL, TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF. Default is INFO
-            # This is an alternative to changing the rootLogger in log4j.properties
+            # This is an alternative to changing the rootLogger in log4j2.xml
             #SOLR_LOG_LEVEL=INFO
 
             # Location where Solr should write logs to. Absolute or relative to solr start dir

--- a/src/main/mpack/common-services/SOLR/7.4.0/configuration/solr-log4j.xml
+++ b/src/main/mpack/common-services/SOLR/7.4.0/configuration/solr-log4j.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration supports_final="false" supports_adding_forbidden="true">
+
+  <property>
+    <name>content</name>
+    <description>Custom log4j2.xml</description>
+    <value>
+      <![CDATA[
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.  --> <Configuration>
+        <Appenders>
+
+          <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout>
+              <Pattern>
+                %d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+              </Pattern>
+            </PatternLayout>
+          </Console>
+
+          <RollingFile
+              name="RollingFile"
+              fileName="{{solr_config_log_dir}}/solr.log"
+              filePattern="{{solr_config_log_dir}}/solr.log.%i" >
+            <PatternLayout>
+              <Pattern>
+                %d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+              </Pattern>
+            </PatternLayout>
+            <Policies>
+              <OnStartupTriggeringPolicy />
+              <SizeBasedTriggeringPolicy size="32 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+          </RollingFile>
+
+          <RollingFile
+              name="SlowFile"
+              fileName="{{solr_config_log_dir}}/solr_slow_requests.log"
+              filePattern="{{solr_config_log_dir}}/solr_slow_requests.log.%i" >
+            <PatternLayout>
+              <Pattern>
+                %d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+              </Pattern>
+            </PatternLayout>
+            <Policies>
+              <OnStartupTriggeringPolicy />
+              <SizeBasedTriggeringPolicy size="32 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+          </RollingFile>
+
+        </Appenders>
+        <Loggers>
+          <Logger name="org.apache.hadoop" level="warn"/>
+          <Logger name="org.apache.solr.update.LoggingInfoStream" level="off"/>
+          <Logger name="org.apache.zookeeper" level="warn"/>
+          <Logger name="org.apache.solr.core.SolrCore.SlowRequest" level="info" additivity="false">
+            <AppenderRef ref="SlowFile"/>
+          </Logger>
+
+          <Root level="info">
+            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="STDOUT"/>
+          </Root>
+        </Loggers>
+      </Configuration>]]>
+    </value>
+    <value-attributes>
+      <type>content</type>
+      <show-property-name>false</show-property-name>
+    </value-attributes>
+  </property>
+</configuration>

--- a/src/main/mpack/common-services/SOLR/7.4.0/package/scripts/setup_solr.py
+++ b/src/main/mpack/common-services/SOLR/7.4.0/package/scripts/setup_solr.py
@@ -34,7 +34,7 @@ def setup_solr():
     )
 
     File(
-            format("{solr_config_conf_dir}/log4j.properties"),
+            format("{solr_config_conf_dir}/log4j2.xml"),
             content=InlineTemplate(params.log4j_properties),
             owner=params.solr_config_user
     )


### PR DESCRIPTION
Solr 7.4.0 uses log4j2 for its logging.  We missed this earlier when updating our mpack to use Solr 7.4.0.  This commit changes the Solr log4j template and filename to work better with log4j2.