### PR TITLE
Fix log4j2 template spacing

### DIFF
--- a/src/main/mpack/common-services/SOLR/7.4.0/configuration/solr-log4j.xml
+++ b/src/main/mpack/common-services/SOLR/7.4.0/configuration/solr-log4j.xml
@@ -6,9 +6,7 @@
   <property>
     <name>content</name>
     <description>Custom log4j2.xml</description>
-    <value>
-      <![CDATA[
-      <?xml version="1.0" encoding="UTF-8"?>
+    <value><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
       <!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.  --> <Configuration>
         <Appenders>
 


### PR DESCRIPTION
The log4j template added some extra newlines before the actual XML
header, causing the logging library that Solr users to choke and fail to
initialize logging.

This commit removes the source of the extra spaces, allowing logging to
start up correctly.